### PR TITLE
Add --ignore-injected-events flag to support key remappers (e.g. kanata)

### DIFF
--- a/src/main/java/mousemaster/ApplicationOptions.java
+++ b/src/main/java/mousemaster/ApplicationOptions.java
@@ -13,7 +13,8 @@ public record ApplicationOptions(String tempDirectory,
                                  Path configurationPath,
                                  boolean multipleInstancesAllowed,
                                  boolean keyRegurgitationEnabled,
-                                 boolean graalvmAgentRun) {
+                                 boolean graalvmAgentRun,
+                                 boolean ignoreInjectedEvents) {
 
     public static ApplicationOptions parse(String[] args) {
         return new ApplicationOptions(
@@ -26,7 +27,8 @@ public record ApplicationOptions(String tempDirectory,
                         "mousemaster.properties")),
                 booleanArg(args, "--multiple-instances-allowed=", false),
                 booleanArg(args, "--key-regurgitation-enabled=", true),
-                Stream.of(args).anyMatch(Predicate.isEqual("--graalvm-agent-run"))
+                Stream.of(args).anyMatch(Predicate.isEqual("--graalvm-agent-run")),
+                booleanArg(args, "--ignore-injected-events=", true)
         );
     }
 

--- a/src/main/java/mousemaster/platform/windows/WindowsMain.java
+++ b/src/main/java/mousemaster/platform/windows/WindowsMain.java
@@ -49,7 +49,8 @@ public class WindowsMain {
             }).start();
         }
         Platform platform = createPlatform(options.multipleInstancesAllowed(),
-                options.keyRegurgitationEnabled(), options.pauseOnError());
+                options.keyRegurgitationEnabled(), options.pauseOnError(),
+                options.ignoreInjectedEvents());
         logger.info("mousemaster v" + version + " (" + commitId + ")");
         if (platform == null)
             return;
@@ -66,9 +67,11 @@ public class WindowsMain {
 
     private static Platform createPlatform(boolean multipleInstancesAllowed,
                                            boolean keyRegurgitationEnabled,
-                                           boolean pauseOnError) {
+                                           boolean pauseOnError,
+                                           boolean ignoreInjectedEvents) {
         try {
-            return new WindowsPlatform(multipleInstancesAllowed, keyRegurgitationEnabled);
+            return new WindowsPlatform(multipleInstancesAllowed, keyRegurgitationEnabled,
+                    ignoreInjectedEvents);
         } catch (Exception e) {
             MousemasterApplication.shutdownAfterException(e, null, false, pauseOnError);
         }

--- a/src/main/java/mousemaster/platform/windows/WindowsPlatform.java
+++ b/src/main/java/mousemaster/platform/windows/WindowsPlatform.java
@@ -217,7 +217,7 @@ public class WindowsPlatform implements Platform {
         if (keyboardHook == null)
             throw new IllegalStateException(
                     "Unable to install keyboard hook " + Native.getLastError());
-        logger.trace("Installed keyboard hook successfully");
+        logger.info("Installed keyboard hook successfully");
         // Run mouse hook in a separate thread to avoid lags:
         // https://www.linkedin.com/pulse/windows-mouse-hook-lagging-simone-galleni
         // https://stackoverflow.com/a/52201983

--- a/src/main/java/mousemaster/platform/windows/WindowsPlatform.java
+++ b/src/main/java/mousemaster/platform/windows/WindowsPlatform.java
@@ -28,6 +28,7 @@ public class WindowsPlatform implements Platform {
     private static final Logger logger = LoggerFactory.getLogger(WindowsPlatform.class);
 
     private final boolean keyRegurgitationEnabled;
+    private final boolean ignoreInjectedEvents;
     private final WindowsKeyboardController keyboard = new WindowsKeyboardController();
     private final WindowsMouseController mouse = new WindowsMouseController(this::mousePositionSet);
     private final Screens screens = new WindowsScreens();
@@ -72,8 +73,10 @@ public class WindowsPlatform implements Platform {
     private Mode currentMode;
     private double stuckKeyCheckTimer;
 
-    public WindowsPlatform(boolean multipleInstancesAllowed, boolean keyRegurgitationEnabled) {
+    public WindowsPlatform(boolean multipleInstancesAllowed, boolean keyRegurgitationEnabled,
+                           boolean ignoreInjectedEvents) {
         this.keyRegurgitationEnabled = keyRegurgitationEnabled;
+        this.ignoreInjectedEvents = ignoreInjectedEvents;
         WindowsUiAccess.checkAndTryToGetUiAccess(); // Done before acquiring the single instance mutex.
         if (!multipleInstancesAllowed && !acquireSingleInstanceMutex())
             throw new IllegalStateException("Another instance is already running");
@@ -478,7 +481,7 @@ public class WindowsPlatform implements Platform {
                             logKeyEvent(info, wParamString, keyEvent, injected, altgrLeftctrl);
                             keyboard.keyboardHookCallback(info, wParam, wParamString,
                                     keyEvent, injected, altgrLeftctrl);
-                            if (injected) {
+                            if (injected && ignoreInjectedEvents) {
                                 if (keyEvent != null) {
                                     if (keyboard.shouldSuppressExternalLeftalt(keyEvent, true)) {
                                         logger.trace("Suppressing external +leftalt");


### PR DESCRIPTION
## Summary

Adds the `--ignore-injected-events` command-line flag (originally prototyped by @petoncle, see #39) on top of current `main`.

mousemaster ignores injected keyboard events (`LLKHF_INJECTED`) by default, so key events produced by remapping software such as [kanata](https://github.com/jtroo/kanata) (which emits via `SendInput` and is therefore flagged injected) never reach mode/combo processing. That makes it impossible to activate or drive mousemaster from those tools.

This flag lets users opt in to processing injected events:

```
mousemaster.exe --ignore-injected-events=false
```

- **Default is `true`**, so behavior is unchanged for anyone who doesn't set it.
- With `=false`, injected key events flow through the normal keyboard path.

## Testing

Built and verified locally on Windows with Oracle GraalVM JDK 21 + MSVC (VS 2022) with a minimal config that activates on a single key; verified via the `ComboWatcher` debug log.

I'm also happy to add automated tests here; if you have any preferences, please let me know!

## Notes

- I also bumped the keyboard-hook-installed log line to INFO so that users of keyboard mappers know the hook has been installed without also logging keystrokes.
- #39 was closed as completed after the reporter switched to the Interception driver, but the flag is still useful for users who can't / don't want to run a kernel driver.
