### PR TITLE
docs: note that "Hide pointer while typing" hides a render-as-cursor indicator (#86)

### DIFF
--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -425,6 +425,13 @@ composited on top, instead of into an overlay window that follows the pointer. N
 behind, since there is nothing to follow. Windows only (default false); it is ignored on macOS,
 where the indicator is always an overlay window.
 
+Because the indicator then *is* the cursor, anything that hides the cursor hides the indicator
+too. In particular, the Windows pointer option "Hide pointer while typing" (on by default)
+hides the cursor on every keystroke until the mouse moves, so with `render-as-cursor` the
+indicator disappears right after a key press and only comes back once the pointer is moved.
+Turn that option off (Mouse Properties > Pointer Options > Visibility) if you see this; the
+overlay indicator is not affected. See [#86](https://github.com/petoncle/mousemaster/issues/86).
+
 #### Fade animation
 
 When the indicator appears, disappears, or changes color (e.g. when switching modes), it fades in and out instead of popping abruptly.


### PR DESCRIPTION
Follow-up to #86, as offered there.

One paragraph under "Rendering as the system cursor" in docs/configuration-reference.md:
with `render-as-cursor` the indicator is the cursor, so the Windows pointer option
"Hide pointer while typing" (on by default) hides it on every keystroke until the mouse
moves. The note says what the symptom looks like, where the option lives
(Mouse Properties > Pointer Options > Visibility), and that the overlay indicator is
not affected. No code changes.

Measured in #86: option on -> indicator disappears one frame after a key press until the
pointer moves (reproduced with a 7-line config); option off -> does not happen;
`render-as-cursor=false` -> does not happen either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)